### PR TITLE
Enable domain based tenancy

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,11 +1,59 @@
 <?php
 
 use DigiFactory\FilamentWildcardLogin\Http\Controllers\WildcardLoginController;
+use Filament\Facades\Filament;
 use Illuminate\Routing\Middleware\ValidateSignature;
+use Illuminate\Routing\RouteRegistrar;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware('web')->group(function () {
-    Route::get('filament-wildcard-login', WildcardLoginController::class)
-        ->name('filament-wildcard-login')
-        ->middleware(ValidateSignature::class);
-});
+Route::name('filament.')
+    ->group(function () {
+        foreach (Filament::getPanels() as $panel) {
+            /** @var Panel $panel */
+            $panelId = $panel->getId();
+            $hasTenancy = $panel->hasTenancy();
+            $tenantRoutePrefix = $panel->getTenantRoutePrefix();
+            $tenantDomain = $panel->getTenantDomain();
+            $tenantSlugAttribute = $panel->getTenantSlugAttribute();
+            $domains = $panel->getDomains();
+
+            foreach ((empty($domains) ? [null] : $domains) as $domain) {
+                Route::domain($domain)
+                    ->middleware($panel->getMiddleware())
+                    ->name("{$panelId}." . ((filled($domain) && (count($domains) > 1)) ? "{$domain}." : ''))
+                    ->prefix($panel->getPath())
+                    ->group(function () use ($hasTenancy, $tenantDomain, $tenantRoutePrefix, $tenantSlugAttribute) {
+                        if ($hasTenancy) {
+                            $routeGroup = app(RouteRegistrar::class);
+
+                            if (filled($tenantDomain)) {
+                                $routeGroup->domain($tenantDomain);
+                            } else {
+                                $routeGroup->prefix(
+                                    (
+                                        filled($tenantRoutePrefix) ?
+                                        "{$tenantRoutePrefix}/" :
+                                        ''
+                                    ) . '{tenant' . (
+                                        filled($tenantSlugAttribute) ?
+                                        ":{$tenantSlugAttribute}" :
+                                        ''
+                                    ) . '}',
+                                );
+                            }
+
+                            $routeGroup
+                                ->group(function (): void {
+                                    Route::get('filament-wildcard-login', WildcardLoginController::class)
+                                        ->name('filament-wildcard-login')
+                                        ->middleware(ValidateSignature::class);
+                                });
+                        } else {
+                            Route::get('filament-wildcard-login', WildcardLoginController::class)
+                                ->name('filament-wildcard-login')
+                                ->middleware(ValidateSignature::class);
+                        }
+                    });
+            }
+        }
+    });

--- a/src/Filament/Pages/Login.php
+++ b/src/Filament/Pages/Login.php
@@ -41,10 +41,15 @@ class Login extends BaseLogin
                         return app(LoginResponse::class);
                     } else {
                         $expiration = now()->addMinutes($plugin->getEmailValidForMinutes());
+                        $parameters = ['user' => $user->id];
+
+                        if (Filament::getCurrentPanel()->hasTenancy()) {
+                            $parameters['tenant'] = Filament::getCurrentPanel()->getTenant(request()->getHost());
+                        }
 
                         $loginUrl = URL::signedRoute(
-                            'filament-wildcard-login',
-                            ['user' => $user->id],
+                            'filament.' . Filament::getCurrentPanel()->getId() . '.filament-wildcard-login',
+                            $parameters,
                             $expiration,
                         );
 


### PR DESCRIPTION
There was an issue with login in to a domain based tenant, because the there was no tenant parameter in the route there was no (decent) option to find out which tenant was being logged in too.